### PR TITLE
change dirs that dependabot looks in

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,14 @@ updates:
  
   - package-ecosystem: "github-actions"
     target-branch: "main"
-    directory: "/"
+    directories: 
+      - "/build-action"
+      - "/hatch-conda"
+      - "/hatch-lint"
+      - "/permission_check"
+      - "/setup-hatch"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "06:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Currently dependabot isn't successfully checking the actions we have - have updated the directories it looks in to get it to work properly 